### PR TITLE
fixed when fluentd.logs.autoscaling.enabled: true error

### DIFF
--- a/deploy/helm/sumologic/templates/logs/fluentd/hpa.yaml
+++ b/deploy/helm/sumologic/templates/logs/fluentd/hpa.yaml
@@ -19,18 +19,18 @@ spec:
   minReplicas: {{ .Values.fluentd.logs.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.fluentd.logs.autoscaling.maxReplicas }}
   metrics:
-{{ if .Values.fluentd.logs.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.fluentd.logs.autoscaling.targetCPUUtilizationPercentage }}
+{{- if .Values.fluentd.logs.autoscaling.targetMemoryUtilizationPercentage }}
   - type: Resource
     resource:
       name: memory
       target:
         type: Utilization
         averageUtilization: {{ .Values.fluentd.logs.autoscaling.targetMemoryUtilizationPercentage }}
-{{ end }}
-  - type: Resource
-    resource:
-      name: cpu
-      target:
-        type: Utilization
-        averageUtilization: {{ .Values.fluentd.logs.autoscaling.targetCPUUtilizationPercentage }}
+{{- end -}}
 {{- end -}}


### PR DESCRIPTION
when `fluentd.logs.autoscaling.enabled: true`

and then 
```
 helm template sumologic-agent ./sumologic  --namespace=sumologic -f values.yaml > manifest.yaml


Error: YAML parse error on sumologic/templates/logs/fluentd/hpa.yaml: error converting YAML to JSON: yaml: line 19: mapping values are not allowed in this context

Use --debug flag to render out invalid YAML

```

helm chart version: 3.12.1
